### PR TITLE
Add Package JSON for facilitating NPM install

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mindnuts/nodessdb.git"
+    "url": "git+https://github.com/ssdb/nodessdb.git"
   },
   "keywords": [
     "foo",
     "bar"
   ],
-  "author": "acsandeep",
-  "license": "ISC",
+  "author": "ideawu",
+  "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mindnuts/nodessdb/issues"
+    "url": "https://github.com/ssdb/nodessdb/issues"
   },
-  "homepage": "https://github.com/mindnuts/nodessdb#readme"
+  "homepage": "https://github.com/ssdb/nodessdb#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "nodessdb",
+  "version": "1.0.0",
+  "description": "SSDB nodejs Client",
+  "main": "SSDB.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mindnuts/nodessdb.git"
+  },
+  "keywords": [
+    "foo",
+    "bar"
+  ],
+  "author": "acsandeep",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/mindnuts/nodessdb/issues"
+  },
+  "homepage": "https://github.com/mindnuts/nodessdb#readme"
+}


### PR DESCRIPTION
After this pull request users can install nodessdb by adding it as a dependency in their Package.json file like so:

```
"dependencies": {    
    "bluebird": "^3.2.2", 
    "ssdb" : "ssdb/nodessdb",
    "deepmerge": "^0.2.10"
    
  }
```