### PR TITLE
Update SSDB.js

### DIFF
--- a/SSDB.js
+++ b/SSDB.js
@@ -46,9 +46,9 @@ exports.connect = function(host, port, timeout, listener){
 	}
 
 	self.request = function(cmd, params, callback){
+		callbacks.push(callback || function(){});
 		var arr = [cmd].concat(params);
 		self.send_request(arr);
-		callbacks.push(callback || function(){});
 	}
 
 	function build_buffer(arr){


### PR DESCRIPTION
Removed possible race condition at function "self.request". The callbacks array shall be populated before calling send_request. Otherwise the callbacks array might still be empty when the request is processed, causing an error.